### PR TITLE
Zeus molpro update

### DIFF
--- a/Servers/Zeus/ARC/.arc/settings.py
+++ b/Servers/Zeus/ARC/.arc/settings.py
@@ -18,9 +18,10 @@ servers = {
 
 global_ess_settings = {
     'gaussian': ['local'],
+    'molpro': ['local']
 }
 
-supported_ess = ['gaussian']
+supported_ess = ['gaussian', 'molpro']
 
 default_job_settings = {
     'job_total_memory_gb': 32,

--- a/Servers/Zeus/ARC/.arc/submit.py
+++ b/Servers/Zeus/ARC/.arc/submit.py
@@ -50,7 +50,7 @@ touch final_time
 PBS_O_WORKDIR={pwd}
 cd $PBS_O_WORKDIR
 
-MOLPRO_SCRDIR=/tmp/{un}/scratch/molpro/$PBS_JOBID
+MOLPRO_SCRDIR=/gtmp/{un}/scratch/molpro/$PBS_JOBID
 export MOLPRO_SCRDIR=$MOLPRO_SCRDIR
 mkdir -p $MOLPRO_SCRDIR
 
@@ -73,6 +73,8 @@ else
 fi
        
 rm -rf $MOLPRO_SCRDIR
+
+cd $PBS_O_WORKDIR
 
 touch final_time
     


### PR DESCRIPTION
- Change the target destination of the scratch folder for Molpro to now be pointed at /gtmp/
- Added molpro into the settings.py file