### PR TITLE
Added mpiprocs to script for CPU recognition

### DIFF
--- a/Servers/Zeus/ARC/.arc/submit.py
+++ b/Servers/Zeus/ARC/.arc/submit.py
@@ -11,7 +11,7 @@ submit_scripts = {
 
 #PBS -q mafat_new_q
 #PBS -N {name}
-#PBS -l select=1:ncpus={cpus}:mem={memory}
+#PBS -l select=1:ncpus={cpus}:mem={memory}:mpiprocs={cpus}
 #PBS -o out.txt
 #PBS -e err.txt
 
@@ -43,7 +43,7 @@ touch final_time
 
 #PBS -q zeus_long_q
 #PBS -N {name}
-#PBS -l select=1:ncpus={cpus}:mem={memory}
+#PBS -l select=1:ncpus={cpus}:mem={memory}:mpiprocs={cpus}
 #PBS -o out.txt
 #PBS -e err.txt
 


### PR DESCRIPTION
Originally, our PBS scripts for Zeus did not properly inform MPI of the number of PROCS available. These changes rectify that issue.