### PR TITLE
Swapped directories in $PATH

### DIFF
--- a/Servers/Atlas/.arc/submit.py
+++ b/Servers/Atlas/.arc/submit.py
@@ -167,7 +167,7 @@ export OrcaDir=/Local/ce_dana/orca_5_0_4_linux_x86-64_shared_openmpi411
 export PATH=$PATH:$OrcaDir
 
 export OMPI_Dir=/Local/ce_dana/openmpi-4.1.1/bin
-export PATH=$PATH:$OMPI_Dir
+export PATH=$OMPI_Dir:$PATH
 
 export LD_LIBRARY_PATH=/Local/ce_dana/orca_5_0_4_linux_x86-64_shared_openmpi411:/Local/ce_dana/openmpi-4.1.1/lib:$LD_LIBRARY_PATH
 


### PR DESCRIPTION
If $PATH is placed first, then ORCA will use openmpi contained in the python environment and therefore does not consider the openmpi contained in /Local/ce_dana/openmpi-4.1.1/bin (first come first served).
Swapping them around allows the correct openmpi (mpiexec) to be chosen
