### PR TITLE
Swapping directories in PATH

### DIFF
--- a/Servers/Zeus/ARC/.arc/submit.py
+++ b/Servers/Zeus/ARC/.arc/submit.py
@@ -155,7 +155,7 @@ export OrcaDir=/usr/local/orca-5.0.4
 export PATH=$PATH:$OrcaDir
 
 export OMPI_Dir=/usr/local/openmpi-4.1.1
-export PATH=$PATH:$OMPI_Dir
+export PATH=$OMPI_Dir:$PATH
 
 export LD_LIBRARY_PATH=/usr/local/openmpi-4.1.1/lib:$LD_LIBRARY_PATH
 


### PR DESCRIPTION
Swapping directories in PATH for the correct openmpi. However, note this isn't important or has an effect due to use sourcing two setup.sh scripts later in the file

```
source /usr/local/orca-5.0.4/setup.sh
source /usr/local/openmpi-4.1.1/setup.sh
```
