### PR TITLE
Updated the alias for RMG and Arkane

### DIFF
--- a/bashrc/.bashrc
+++ b/bashrc/.bashrc
@@ -36,8 +36,8 @@ alias t3code='cd $t3_path'
 
 alias j='cd ~/scripts && jupyter notebook'
 
-alias rmg='python-jl $rmgpy_path/rmg.py input.py  > >(tee -a stdout.log) 2> >(tee -a stderr.log >&2)'
-alias arkane='python-jl $rmgpy_path/Arkane.py input.py  > >(tee -a stdout.log) 2> >(tee -a stderr.log >&2)'
+alias rmg='python $rmgpy_path/rmg.py input.py  > >(tee -a stdout.log) 2> >(tee -a stderr.log >&2)'
+alias arkane='python $rmgpy_path/Arkane.py input.py  > >(tee -a stdout.log) 2> >(tee -a stderr.log >&2)'
 alias arc='python $arc_path/ARC.py input.yml  > >(tee -a stdout.log) 2> >(tee -a stderr.log >&2)'
 alias arcrestart='python $arc_path/ARC.py restart.yml  > >(tee -a stdout.log) 2> >(tee -a stderr.log >&2)'
 alias t3='python $t3_path/T3.py input.yml  > >(tee -a stdout.log) 2> >(tee -a stderr.log >&2)'


### PR DESCRIPTION
RMG 3.9 does not use `-jl` anymore inorder to run the python command. 